### PR TITLE
Zinc Symbol Support

### DIFF
--- a/ProjectHaystack/Values/HaystackCaretSymbol.cs
+++ b/ProjectHaystack/Values/HaystackCaretSymbol.cs
@@ -12,8 +12,6 @@ namespace ProjectHaystack
                 : throw new ArgumentException($"Invalid id val: {value}", "value");
         }
 
-        public static HaystackReference nullRef = new HaystackReference(null, null);
-
         public string Value { get; }
         public string Code => "^" + Value;
 

--- a/ProjectHaystack/Values/HaystackCaretSymbol.cs
+++ b/ProjectHaystack/Values/HaystackCaretSymbol.cs
@@ -1,0 +1,24 @@
+using System;
+using ProjectHaystack.Validation;
+
+namespace ProjectHaystack
+{
+    public class HaystackCaretSymbol : HaystackValue
+    {
+        public HaystackCaretSymbol(string value)
+        {
+            Value = value == null || HaystackValidator.IsReferenceId(value)
+                ? value
+                : throw new ArgumentException($"Invalid id val: {value}", "value");
+        }
+
+        public static HaystackReference nullRef = new HaystackReference(null, null);
+
+        public string Value { get; }
+        public string Code => "^" + Value;
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override bool Equals(object other) => other != null && other is HaystackReference reference && (reference.Value?.Equals(Value) ?? false);
+    }
+}

--- a/ProjectHaystack/io/HaystackToken.cs
+++ b/ProjectHaystack/io/HaystackToken.cs
@@ -11,6 +11,7 @@
         public static HaystackToken num = new HaystackToken("Number", true);
         public static HaystackToken str = new HaystackToken("Str", true);
         public static HaystackToken @ref = new HaystackToken("Ref", true);
+        public static HaystackToken caretSymbol = new HaystackToken("Symbol", true);
         public static HaystackToken uri = new HaystackToken("Uri", true);
         public static HaystackToken date = new HaystackToken("Date", true);
         public static HaystackToken time = new HaystackToken("Time", true);

--- a/ProjectHaystack/io/HaystackTokenizer.cs
+++ b/ProjectHaystack/io/HaystackTokenizer.cs
@@ -92,6 +92,7 @@ namespace ProjectHaystack.io
                 if (isIdStart(_currentChar)) return _currentToken = ReadId();
                 if (_currentChar == '"') return _currentToken = ReadString();
                 if (_currentChar == '@') return _currentToken = ReadReference();
+                if (_currentChar == '^') return _currentToken = ReadCaretSymbol();
                 if (isDigit(_currentChar)) return _currentToken = ReadNumber();
                 if (_currentChar == '`') return _currentToken = ReadUri();
                 if (_currentChar == '-' && isDigit(_peekChar)) return _currentToken = ReadNumber();
@@ -119,7 +120,6 @@ namespace ProjectHaystack.io
         private static bool isIdStart(int cur)
         {
             if (cur < 0) return false;
-            if ((char)cur == '^') return true;
             if ('a' <= (char)cur && (char)cur <= 'z') return true;
             if ('A' <= (char)cur && (char)cur <= 'Z') return true;
             return false;
@@ -621,6 +621,27 @@ namespace ProjectHaystack.io
             }
             _currentValue = new HaystackReference(s.ToString(), null);
             return HaystackToken.@ref;
+        }
+
+        private HaystackToken ReadCaretSymbol()
+        {
+            if (_currentChar < 0) err("Unexpected eof in refh");
+            consume('^');
+            StringBuilder s = new StringBuilder();
+            while (true)
+            {
+                if (HaystackValidator.IsReferenceIdChar((char)_currentChar))
+                {
+                    s.Append((char)_currentChar);
+                    consume();
+                }
+                else
+                {
+                    break;
+                }
+            }
+            _currentValue = new HaystackCaretSymbol(s.ToString());
+            return HaystackToken.caretSymbol;
         }
 
         private HaystackToken ReadUri()


### PR DESCRIPTION
Added support for Zinc Symbol(caret) to tokenizer

This came up in attempting to make use of the library with Haxall 3.1.3
OpsAsync was throwing due to the usage of the Symbol type in the Zinc response.
ie;
```
ver:"3.0"
def,doc,is,lib,noSideEffects,typeName
^op:invokeAction,"Invoke a user action on a target entity.\nSee `docHaystack::Ops#invokeAction` chapter.",[^op],^lib:phIoT,,
```

Changes based on documentation of Zinc: https://project-haystack.org/doc/docHaystack/Zinc