### PR TITLE
Fix typo in the ScramAuthenticator

### DIFF
--- a/ProjectHaystack/Auth/ScramAuthenticator.cs
+++ b/ProjectHaystack/Auth/ScramAuthenticator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ProjectHaystack.Util;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -6,7 +7,6 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using ProjectHaystack.Util;
 
 namespace ProjectHaystack.Auth
 {
@@ -115,7 +115,7 @@ namespace ProjectHaystack.Auth
             message.Headers.Authorization = new AuthenticationHeaderValue("scram",
                DictToToken(new Dictionary<string, string>
                {
-                   ["data"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(c2_no_proof + ",p= " + clientProof)),
+                   ["data"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(c2_no_proof + ",p=" + clientProof)),
                    ["handshakeToken"] = _lastMessage["handshakeToken"],
                }));
             var response = await client.SendAsync(message);


### PR DESCRIPTION
Hi Haystack C# client team.
I fixed the typo - additional space before client proof. 