### PR TITLE
Make the space before the client proof in SCRAM authentication optional.

### DIFF
--- a/Examples/Client/AuthenticationExamples.cs
+++ b/Examples/Client/AuthenticationExamples.cs
@@ -24,6 +24,8 @@ namespace ProjectHaystack.Examples.Client
             var pass = "somepassword";
             var uri = new Uri("https://someserver/api/");
             var auth = new ScramAuthenticator(user, pass);
+            // When authentications fails in certain legacy systems, set this value to true.
+            auth.AddLegacySpaceToProof = true;
             var client = new HaystackClient(auth, uri);
             await client.OpenAsync();
         }


### PR DESCRIPTION
Fixes #112
+semver: breaking